### PR TITLE
Undefined index installation-source

### DIFF
--- a/src/LEtudiant/Composer/Data/Package/SharedPackageDataManager.php
+++ b/src/LEtudiant/Composer/Data/Package/SharedPackageDataManager.php
@@ -157,7 +157,7 @@ class SharedPackageDataManager implements PackageDataManagerInterface
         }
 
         $packageKey = $package->getPrettyName() . '/' . $package->getPrettyVersion();
-        if (!isset($this->packagesData[$packageKey])) {
+        if (!isset($this->packagesData[$packageKey]) || !isset($this->packagesData[$packageKey][$key])) {
             return $defaultValue;
         }
 


### PR DESCRIPTION
Probably caused by #18, 'installation-source' field can be missing in package cache. Just add test and return default